### PR TITLE
Fix setup.py dependencies section that prevents using setuptools installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,15 @@ setup(
     zip_safe=False,
     install_requires=[
         'sqlalchemy==0.7.4',
-        'Flask==0.8', 
+        'Flask==0.8',
         'Flask-Script==0.3.1',
         'flask-sqlalchemy==0.15',
         'colander==0.9.4',
         'Unidecode==0.04.9',
         'sqlalchemy-migrate==0.7.2',
-        'python-dateutil=2.0',
+        'python-dateutil==2.0',
         'flask-login==0.1',
-        'formencode=1.2.4'
+        'formencode==1.2.4'
     ],
     tests_require=[],
     entry_points=\


### PR DESCRIPTION
Hi, just corrected the setup.py that was preventing me from installing grano using standard python setuptools

Regards

fixes #10
