### PR TITLE
Changes to setup.py and the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ $ cp grano/default_settings.py settings.py
 # edit the file to have a working DB connection string etc.
 $ export GRANO_SETTINGS=settings.py
 
+# Install your Database Backend (If needed)
+$ pip install psycopg2
+
+# Create the Database
+$ python grano/manage.py createdb
+
 # Finally, run Grano:
 $ python grano/web.py 
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
         'sqlalchemy-migrate==0.7.2',
         'python-dateutil==2.0',
         'flask-login==0.1',
-        'formencode==1.2.4'
+        'formencode==1.2.4',
+        'networkx==1.7',
     ],
     tests_require=[],
     entry_points=\


### PR DESCRIPTION
Tried to install grano today and ran into two issues: networkx is not listed in the requirements and the README says nothing about creating the database and installing the necessary backend (psycopg2 in case of postgres). I therefore edited the setup.py and the README to fix these issues.
